### PR TITLE
build the gitbin snap package with goreleaser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-language: go
+dist: trusty
+sudo: required
 
-sudo: false
+language: go
 
 go:
     - 1.7.x
@@ -20,5 +21,9 @@ script: make check
 after_success: >
     if [[ "$TRAVIS_TAG" && $TRAVIS_GO_VERSION =~ ^1\.8(\.[0-9]+)?$ ]]; then
         gitbin get goreleaser/goreleaser 0.28.3 -o $HOME/bin
+        sudo apt-get update
+        sudo apt-get install --yes snapd
+        export PATH=/snap/bin:$PATH
+        sudo snap install snapcraft --candidate --classic
         goreleaser
     fi

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -14,3 +14,10 @@ archive:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     replacements:
         dummy: dummy # Required because replacements are checked for length (https://github.com/goreleaser/goreleaser/blob/3ed26ed83b083dbd4267ad6bf5fc5282b2e5942c/pipeline/defaults/defaults.go#L53)
+
+snapcraft:
+  summary: Github binary downloader
+  description: Github binary downloader
+  apps:
+    gitbin:
+      plugs: [home, network]


### PR DESCRIPTION
This package will let you publish the latest gitbin in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.